### PR TITLE
Remove column matching

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -18,6 +18,10 @@ class Govet(Linter):
 
     syntax = ('go', 'gosublime-go')
     cmd = ('go', 'tool', 'vet')
-    regex = r'^.+:(?P<line>\d+):(?P<col>\d+):\s+(?P<message>.+)'
+    regex = r'^.+:(?P<line>\d+):\s+(?P<message>.+)'
     tempfile_suffix = 'go'
     error_stream = util.STREAM_STDERR
+
+    def split_match(self, match):
+        match, line, col, error, warning, message, near = super().split_match(match)
+        return match, line, 0, error, warning, message, near

--- a/linter.py
+++ b/linter.py
@@ -18,6 +18,6 @@ class Govet(Linter):
 
     syntax = ('go', 'gosublime-go')
     cmd = ('go', 'tool', 'vet')
-    regex = r'.+?:(?P<line>\d+):((?P<col>\d+):)?(?P<message>.+)'
+    regex = r'.+?:(?P<line>\d+):((?P<col>\d+):)?\s+(?P<message>.+)'
     tempfile_suffix = 'go'
     error_stream = util.STREAM_STDERR

--- a/linter.py
+++ b/linter.py
@@ -18,11 +18,6 @@ class Govet(Linter):
 
     syntax = ('go', 'gosublime-go')
     cmd = ('go', 'tool', 'vet')
-    regex = r'^.+:(?P<line>\d+):\s+(?P<message>.+)'
+    regex = r'.+?:(?P<line>\d+):((?P<col>\d+):)?(?P<message>.+)'
     tempfile_suffix = 'go'
     error_stream = util.STREAM_STDERR
-
-    """Let the linter higlight column 0"""
-    def split_match(self, match):
-        match, line, col, error, warning, message, near = super().split_match(match)
-        return match, line, 0, error, warning, message, near

--- a/linter.py
+++ b/linter.py
@@ -22,6 +22,7 @@ class Govet(Linter):
     tempfile_suffix = 'go'
     error_stream = util.STREAM_STDERR
 
+    """Let the linter higlight column 0"""
     def split_match(self, match):
         match, line, col, error, warning, message, near = super().split_match(match)
         return match, line, 0, error, warning, message, near


### PR DESCRIPTION
Currently (go1.9.2), this linter do not match any vet errors since now the output of vet has no column info.
For example, `/var/folders/32/w4v1btt162gg6sq9cq01z5y40000gn/T/tmpfytxiu.go:328: missing argument for Errorf("%v"): format reads arg 2, have only 1 args`.

So I removed the column matching from regex and now it works!
But there is one problem that SublimeLinter do not highlight the line if there is no column matching.
For solve this problem, I let just highlight column 0 of error line, haha.